### PR TITLE
update connect-mongo and express-session versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var _ = require("underscore")
 module.exports = function(plasma, dna) {
   plasma.on(dna.reactOn, function(c){
     var app = c.data || c[0].data
-    var sessionStore = new MongoStore(_.extend({db: dna.db}, dna["connect-mongo"]), function(e){
+    var sessionStore = new MongoStore(_.extend({db: dna.db}, dna["connect-mongo"]))
+    sessionStore.once('connected', function(){
       if(dna.emitReady)
         plasma.emit({
           type: dna.emitReady,
@@ -13,21 +14,21 @@ module.exports = function(plasma, dna) {
           session: session
         })
     })
-    
+
     var session = Session(_.extend({
       secret: dna.cookie_secret,
       store: sessionStore,
       saveUninitialized: true,
       resave: true
     }, dna["express-session"]));
-    
+
     app.use(session);
 
     plasma.on(dna.closeOn || "kill", function(c, next){
       // close db connection
       sessionStore.db.close(function(){
         // workaround to notify express session that its sessionStore has closed db connection.
-        sessionStore.emit("disconnect")
+        sessionStore.emit("disconnected")
         next()
       })
     })

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "organic-express-mongo-sessions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Organelle mounting `connect-mongo` middleware to express app chemical.",
   "main": "index.js",
   "dependencies": {
-    "connect-mongo": "~0.4.1",
-    "express-session": "~1.8.2",
+    "connect-mongo": "^0.8.2",
+    "express-session": "^1.12.1",
     "underscore": "~1.6.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
without this update i get this, caused by fsevents (and bson) build fail

```
{ [Error: Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }
js-bson: Failed to load c++ bson extension, using pure JS version
```
- events are 'connected' and 'disconnected'
